### PR TITLE
Correct the name of the private key in 1 of the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ resource "tls_private_key" "reg_private_key" {
 
 resource "acme_registration" "reg" {
   server_url      = "https://acme-staging.api.letsencrypt.org/directory"
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
+  account_key_pem = "${tls_private_key.reg_private_key.private_key_pem}"
   email_address   = "nobody@example.com"
 }
 


### PR DESCRIPTION
Just a small correction in 1 of the examples.

Thanks for creating this plugin!