### PR TITLE
Upgrade dnsimple provider to support API V2

### DIFF
--- a/vendor/github.com/dnsimple/dnsimple-go/LICENSE.txt
+++ b/vendor/github.com/dnsimple/dnsimple-go/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2017 Sebastian Erhart
+Copyright (c) 2014-2017 Aetrion LLC dba DNSimple
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/accounts.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/accounts.go
@@ -1,0 +1,43 @@
+package dnsimple
+
+import ()
+
+type AccountsService struct {
+	client *Client
+}
+
+// Account represents a DNSimple account.
+type Account struct {
+	ID             int    `json:"id,omitempty"`
+	Email          string `json:"email,omitempty"`
+	PlanIdentifier string `json:"plan_identifier,omitempty"`
+	CreatedAt      string `json:"created_at,omitempty"`
+	UpdatedAt      string `json:"updated_at,omitempty"`
+}
+
+// accountsResponse represents a response from an API method that returns a collection of Account struct.
+type accountsResponse struct {
+	Response
+	Data []Account `json:"data"`
+}
+
+// ListAccounts list the accounts for an user.
+//
+// See https://developer.dnsimple.com/v2/accounts/#list
+func (s *AccountsService) ListAccounts(options *ListOptions) (*accountsResponse, error) {
+	path := versioned("/accounts")
+	accountsResponse := &accountsResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, accountsResponse)
+	if err != nil {
+		return accountsResponse, err
+	}
+
+	accountsResponse.HttpResponse = resp
+	return accountsResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/authentication.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/authentication.go
@@ -1,0 +1,68 @@
+package dnsimple
+
+import (
+	"encoding/base64"
+)
+
+const (
+	httpHeaderDomainToken   = "X-DNSimple-Domain-Token"
+	httpHeaderApiToken      = "X-DNSimple-Token"
+	httpHeaderAuthorization = "Authorization"
+)
+
+// Provides credentials that can be used for authenticating with DNSimple.
+//
+// See https://developer.dnsimple.com/v2/#authentication
+type Credentials interface {
+	// Returns the HTTP headers that should be set
+	// to authenticate the HTTP Request.
+	Headers() map[string]string
+}
+
+// Domain token authentication
+type domainTokenCredentials struct {
+	domainToken string
+}
+
+// NewDomainTokenCredentials construct Credentials using the DNSimple Domain Token method.
+func NewDomainTokenCredentials(domainToken string) Credentials {
+	return &domainTokenCredentials{domainToken: domainToken}
+}
+
+func (c *domainTokenCredentials) Headers() map[string]string {
+	return map[string]string{httpHeaderDomainToken: c.domainToken}
+}
+
+// HTTP basic authentication
+type httpBasicCredentials struct {
+	email    string
+	password string
+}
+
+// NewHTTPBasicCredentials construct Credentials using HTTP Basic Auth.
+func NewHTTPBasicCredentials(email, password string) Credentials {
+	return &httpBasicCredentials{email, password}
+}
+
+func (c *httpBasicCredentials) Headers() map[string]string {
+	return map[string]string{httpHeaderAuthorization: "Basic " + c.basicAuth(c.email, c.password)}
+}
+
+func (c *httpBasicCredentials) basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+// OAuth token authentication
+type oauthTokenCredentials struct {
+	oauthToken string
+}
+
+// NewOauthTokenCredentials construct Credentials using the OAuth access token.
+func NewOauthTokenCredentials(oauthToken string) Credentials {
+	return &oauthTokenCredentials{oauthToken: oauthToken}
+}
+
+func (c *oauthTokenCredentials) Headers() map[string]string {
+	return map[string]string{httpHeaderAuthorization: "Bearer " + c.oauthToken}
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/certificates.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/certificates.go
@@ -1,0 +1,134 @@
+package dnsimple
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// CertificatesService handles communication with the certificate related
+// methods of the DNSimple API.
+//
+// See https://developer.dnsimple.com/v2/domains/certificates
+type CertificatesService struct {
+	client *Client
+}
+
+// Certificate represents a Certificate in DNSimple.
+type Certificate struct {
+	ID                  int    `json:"id,omitempty"`
+	DomainID            int    `json:"domain_id,omitempty"`
+	CommonName          string `json:"common_name,omitempty"`
+	Years               int    `json:"years,omitempty"`
+	State               string `json:"state,omitempty"`
+	AuthorityIdentifier string `json:"authority_identifier,omitempty"`
+	CreatedAt           string `json:"created_at,omitempty"`
+	UpdatedAt           string `json:"updated_at,omitempty"`
+	ExpiresOn           string `json:"expires_on,omitempty"`
+	CertificateRequest  string `json:"csr,omitempty"`
+}
+
+// CertificateBundle represents a container for all the PEM-encoded X509 certificate entities,
+// such as the private key, the server certificate and the intermediate chain.
+type CertificateBundle struct {
+	// CertificateRequest       string   `json:"csr,omitempty"`
+	PrivateKey               string   `json:"private_key,omitempty"`
+	ServerCertificate        string   `json:"server,omitempty"`
+	RootCertificate          string   `json:"root,omitempty"`
+	IntermediateCertificates []string `json:"chain,omitempty"`
+}
+
+func certificatePath(accountID, domainIdentifier, certificateID string) (path string) {
+	path = fmt.Sprintf("%v/certificates", domainPath(accountID, domainIdentifier))
+	if certificateID != "" {
+		path += fmt.Sprintf("/%v", certificateID)
+	}
+	return
+}
+
+// certificateResponse represents a response from an API method that returns a Certificate struct.
+type certificateResponse struct {
+	Response
+	Data *Certificate `json:"data"`
+}
+
+// certificateBundleResponse represents a response from an API method that returns a CertificatBundle struct.
+type certificateBundleResponse struct {
+	Response
+	Data *CertificateBundle `json:"data"`
+}
+
+// certificatesResponse represents a response from an API method that returns a collection of Certificate struct.
+type certificatesResponse struct {
+	Response
+	Data []Certificate `json:"data"`
+}
+
+// ListCertificates list the certificates for a domain.
+//
+// See https://developer.dnsimple.com/v2/domains/certificates#list
+func (s *CertificatesService) ListCertificates(accountID, domainIdentifier string, options *ListOptions) (*certificatesResponse, error) {
+	path := versioned(certificatePath(accountID, domainIdentifier, ""))
+	certificatesResponse := &certificatesResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, certificatesResponse)
+	if err != nil {
+		return certificatesResponse, err
+	}
+
+	certificatesResponse.HttpResponse = resp
+	return certificatesResponse, nil
+}
+
+// GetCertificate fetches the certificate.
+//
+// See https://developer.dnsimple.com/v2/domains/certificates#get
+func (s *CertificatesService) GetCertificate(accountID, domainIdentifier string, certificateID int) (*certificateResponse, error) {
+	path := versioned(certificatePath(accountID, domainIdentifier, strconv.Itoa(certificateID)))
+	certificateResponse := &certificateResponse{}
+
+	resp, err := s.client.get(path, certificateResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	certificateResponse.HttpResponse = resp
+	return certificateResponse, nil
+}
+
+// DownloadCertificate download the issued server certificate,
+// as well the root certificate and the intermediate chain.
+//
+// See https://developer.dnsimple.com/v2/domains/certificates#download
+func (s *CertificatesService) DownloadCertificate(accountID, domainIdentifier string, certificateID int) (*certificateBundleResponse, error) {
+	path := versioned(certificatePath(accountID, domainIdentifier, strconv.Itoa(certificateID)) + "/download")
+	certificateBundleResponse := &certificateBundleResponse{}
+
+	resp, err := s.client.get(path, certificateBundleResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	certificateBundleResponse.HttpResponse = resp
+	return certificateBundleResponse, nil
+}
+
+// GetCertificatePrivateKey fetches the certificate private key.
+//
+// See https://developer.dnsimple.com/v2/domains/certificates#get-private-key
+func (s *CertificatesService) GetCertificatePrivateKey(accountID, domainIdentifier string, certificateID int) (*certificateBundleResponse, error) {
+	path := versioned(certificatePath(accountID, domainIdentifier, strconv.Itoa(certificateID)) + "/private_key")
+	certificateBundleResponse := &certificateBundleResponse{}
+
+	resp, err := s.client.get(path, certificateBundleResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	certificateBundleResponse.HttpResponse = resp
+	return certificateBundleResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/contacts.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/contacts.go
@@ -1,0 +1,140 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// ContactsService handles communication with the contact related
+// methods of the DNSimple API.
+//
+// See https://developer.dnsimple.com/v2/contacts/
+type ContactsService struct {
+	client *Client
+}
+
+// Contact represents a Contact in DNSimple.
+type Contact struct {
+	ID            int    `json:"id,omitempty"`
+	AccountID     int    `json:"account_id,omitempty"`
+	Label         string `json:"label,omitempty"`
+	FirstName     string `json:"first_name,omitempty"`
+	LastName      string `json:"last_name,omitempty"`
+	JobTitle      string `json:"job_title,omitempty"`
+	Organization  string `json:"organization_name,omitempty"`
+	Address1      string `json:"address1,omitempty"`
+	Address2      string `json:"address2,omitempty"`
+	City          string `json:"city,omitempty"`
+	StateProvince string `json:"state_province,omitempty"`
+	PostalCode    string `json:"postal_code,omitempty"`
+	Country       string `json:"country,omitempty"`
+	Phone         string `json:"phone,omitempty"`
+	Fax           string `json:"fax,omitempty"`
+	Email         string `json:"email,omitempty"`
+	CreatedAt     string `json:"created_at,omitempty"`
+	UpdatedAt     string `json:"updated_at,omitempty"`
+}
+
+func contactPath(accountID string, contactID int) (path string) {
+	path = fmt.Sprintf("/%v/contacts", accountID)
+	if contactID != 0 {
+		path += fmt.Sprintf("/%v", contactID)
+	}
+	return
+}
+
+// contactResponse represents a response from an API method that returns a Contact struct.
+type contactResponse struct {
+	Response
+	Data *Contact `json:"data"`
+}
+
+// contactsResponse represents a response from an API method that returns a collection of Contact struct.
+type contactsResponse struct {
+	Response
+	Data []Contact `json:"data"`
+}
+
+// ListContacts list the contacts for an account.
+//
+// See https://developer.dnsimple.com/v2/contacts/#list
+func (s *ContactsService) ListContacts(accountID string, options *ListOptions) (*contactsResponse, error) {
+	path := versioned(contactPath(accountID, 0))
+	contactsResponse := &contactsResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, contactsResponse)
+	if err != nil {
+		return contactsResponse, err
+	}
+
+	contactsResponse.HttpResponse = resp
+	return contactsResponse, nil
+}
+
+// CreateContact creates a new contact.
+//
+// See https://developer.dnsimple.com/v2/contacts/#create
+func (s *ContactsService) CreateContact(accountID string, contactAttributes Contact) (*contactResponse, error) {
+	path := versioned(contactPath(accountID, 0))
+	contactResponse := &contactResponse{}
+
+	resp, err := s.client.post(path, contactAttributes, contactResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	contactResponse.HttpResponse = resp
+	return contactResponse, nil
+}
+
+// GetContact fetches a contact.
+//
+// See https://developer.dnsimple.com/v2/contacts/#get
+func (s *ContactsService) GetContact(accountID string, contactID int) (*contactResponse, error) {
+	path := versioned(contactPath(accountID, contactID))
+	contactResponse := &contactResponse{}
+
+	resp, err := s.client.get(path, contactResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	contactResponse.HttpResponse = resp
+	return contactResponse, nil
+}
+
+// UpdateContact updates a contact.
+//
+// See https://developer.dnsimple.com/v2/contacts/#update
+func (s *ContactsService) UpdateContact(accountID string, contactID int, contactAttributes Contact) (*contactResponse, error) {
+	path := versioned(contactPath(accountID, contactID))
+	contactResponse := &contactResponse{}
+
+	resp, err := s.client.patch(path, contactAttributes, contactResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	contactResponse.HttpResponse = resp
+	return contactResponse, nil
+}
+
+// DeleteContact PERMANENTLY deletes a contact from the account.
+//
+// See https://developer.dnsimple.com/v2/contacts/#delete
+func (s *ContactsService) DeleteContact(accountID string, contactID int) (*contactResponse, error) {
+	path := versioned(contactPath(accountID, contactID))
+	contactResponse := &contactResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	contactResponse.HttpResponse = resp
+	return contactResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/dnsimple.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/dnsimple.go
@@ -1,0 +1,341 @@
+// Package dnsimple provides a client for the DNSimple API.
+// In order to use this package you will need a DNSimple account.
+package dnsimple
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/go-querystring/query"
+)
+
+const (
+	// Version identifies the current library version.
+	// This is a pro-forma convention given that Go dependencies
+	// tends to be fetched directly from the repo.
+	// It is also used in the user-agent identify the client.
+	Version = "0.15.0"
+
+	// defaultBaseURL to the DNSimple production API.
+	defaultBaseURL = "https://api.dnsimple.com"
+
+	// userAgent represents the default user agent used
+	// when no other user agent is set.
+	defaultUserAgent = "dnsimple-go/" + Version
+
+	apiVersion = "v2"
+)
+
+// Client represents a client to the DNSimple API.
+type Client struct {
+	// HttpClient is the underlying HTTP client
+	// used to communicate with the API.
+	HttpClient *http.Client
+
+	// Credentials used for accessing the DNSimple API
+	Credentials Credentials
+
+	// BaseURL for API requests.
+	// Defaults to the public DNSimple API, but can be set to a different endpoint (e.g. the sandbox).
+	BaseURL string
+
+	// UserAgent used when communicating with the DNSimple API.
+	UserAgent string
+
+	// Services used for talking to different parts of the DNSimple API.
+	Identity          *IdentityService
+	Accounts          *AccountsService
+	Certificates      *CertificatesService
+	Contacts          *ContactsService
+	Domains           *DomainsService
+	Oauth             *OauthService
+	Registrar         *RegistrarService
+	Services          *ServicesService
+	Templates         *TemplatesService
+	Tlds              *TldsService
+	VanityNameServers *VanityNameServersService
+	Webhooks          *WebhooksService
+	Zones             *ZonesService
+
+	// Set to true to output debugging logs during API calls
+	Debug bool
+}
+
+// ListOptions contains the common options you can pass to a List method
+// in order to control parameters such as paginations and page number.
+type ListOptions struct {
+	// The page to return
+	Page int `url:"page,omitempty"`
+
+	// The number of entries to return per page
+	PerPage int `url:"per_page,omitempty"`
+
+	// The order criteria to sort the results.
+	// The value is a comma-separated list of field[:direction],
+	// eg. name | name:desc | name:desc,expiration:desc
+	Sort string `url:"sort,omitempty"`
+}
+
+// NewClient returns a new DNSimple API client using the given credentials.
+func NewClient(credentials Credentials) *Client {
+	c := &Client{Credentials: credentials, HttpClient: &http.Client{}, BaseURL: defaultBaseURL}
+	c.Identity = &IdentityService{client: c}
+	c.Accounts = &AccountsService{client: c}
+	c.Certificates = &CertificatesService{client: c}
+	c.Contacts = &ContactsService{client: c}
+	c.Domains = &DomainsService{client: c}
+	c.Oauth = &OauthService{client: c}
+	c.Registrar = &RegistrarService{client: c}
+	c.Services = &ServicesService{client: c}
+	c.Templates = &TemplatesService{client: c}
+	c.Tlds = &TldsService{client: c}
+	c.VanityNameServers = &VanityNameServersService{client: c}
+	c.Webhooks = &WebhooksService{client: c}
+	c.Zones = &ZonesService{client: c}
+	return c
+}
+
+// NewRequest creates an API request.
+// The path is expected to be a relative path and will be resolved
+// according to the BaseURL of the Client. Paths should always be specified without a preceding slash.
+func (c *Client) NewRequest(method, path string, payload interface{}) (*http.Request, error) {
+	url := c.BaseURL + path
+
+	body := new(bytes.Buffer)
+	if payload != nil {
+		err := json.NewEncoder(body).Encode(payload)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("User-Agent", formatUserAgent(c.UserAgent))
+	for key, value := range c.Credentials.Headers() {
+		req.Header.Add(key, value)
+	}
+
+	return req, nil
+}
+
+// formatUserAgent builds the final user agent to use for HTTP requests.
+//
+// If no custom user agent is provided, the default user agent is used.
+//
+//     dnsimple-go/1.0
+//
+// If a custom user agent is provided, the final user agent is the combination of the custom user agent
+// prepended by the default user agent.
+//
+//     dnsimple-go/1.0 customAgentFlag
+//
+func formatUserAgent(customUserAgent string) string {
+	if customUserAgent == "" {
+		return defaultUserAgent
+	}
+
+	return fmt.Sprintf("%s %s", defaultUserAgent, customUserAgent)
+}
+
+func versioned(path string) string {
+	return fmt.Sprintf("/%s/%s", apiVersion, strings.Trim(path, "/"))
+}
+
+func (c *Client) get(path string, obj interface{}) (*http.Response, error) {
+	req, err := c.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req, obj)
+}
+
+func (c *Client) post(path string, payload, obj interface{}) (*http.Response, error) {
+	req, err := c.NewRequest("POST", path, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req, obj)
+}
+
+func (c *Client) put(path string, payload, obj interface{}) (*http.Response, error) {
+	req, err := c.NewRequest("PUT", path, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req, obj)
+}
+
+func (c *Client) patch(path string, payload, obj interface{}) (*http.Response, error) {
+	req, err := c.NewRequest("PATCH", path, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req, obj)
+}
+
+func (c *Client) delete(path string, payload interface{}, obj interface{}) (*http.Response, error) {
+	req, err := c.NewRequest("DELETE", path, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Do(req, obj)
+}
+
+// Do sends an API request and returns the API response.
+//
+// The API response is JSON decoded and stored in the value pointed by obj,
+// or returned as an error if an API error has occurred.
+// If obj implements the io.Writer interface, the raw response body will be written to obj,
+// without attempting to decode it.
+func (c *Client) Do(req *http.Request, obj interface{}) (*http.Response, error) {
+	if c.Debug {
+		log.Printf("Executing request (%v): %#v", req.URL, req)
+	}
+
+	resp, err := c.HttpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if c.Debug {
+		log.Printf("Response received: %#v", resp)
+	}
+
+	err = CheckResponse(resp)
+	if err != nil {
+		return resp, err
+	}
+
+	// If obj implements the io.Writer,
+	// the response body is decoded into v.
+	if obj != nil {
+		if w, ok := obj.(io.Writer); ok {
+			io.Copy(w, resp.Body)
+		} else {
+			err = json.NewDecoder(resp.Body).Decode(obj)
+		}
+	}
+
+	return resp, err
+}
+
+// A Response represents an API response.
+type Response struct {
+	// HTTP response
+	HttpResponse *http.Response
+
+	// If the response is paginated, the Pagination will store them.
+	Pagination *Pagination `json:"pagination"`
+}
+
+// RateLimit returns the maximum amount of requests this account can send in an hour.
+func (r *Response) RateLimit() int {
+	value, _ := strconv.Atoi(r.HttpResponse.Header.Get("X-RateLimit-Limit"))
+	return value
+}
+
+// RateLimitRemaining returns the remaining amount of requests this account can send within this hour window.
+func (r *Response) RateLimitRemaining() int {
+	value, _ := strconv.Atoi(r.HttpResponse.Header.Get("X-RateLimit-Remaining"))
+	return value
+}
+
+// RateLimitReset returns when the throttling window will be reset for this account.
+func (r *Response) RateLimitReset() time.Time {
+	value, _ := strconv.ParseInt(r.HttpResponse.Header.Get("X-RateLimit-Reset"), 10, 64)
+	return time.Unix(value, 0)
+}
+
+// If the response is paginated, Pagination represents the pagination information.
+type Pagination struct {
+	CurrentPage  int `json:"current_page"`
+	PerPage      int `json:"per_page"`
+	TotalPages   int `json:"total_pages"`
+	TotalEntries int `json:"total_entries"`
+}
+
+// An ErrorResponse represents an API response that generated an error.
+type ErrorResponse struct {
+	Response
+
+	// human-readable message
+	Message string `json:"message"`
+}
+
+// Error implements the error interface.
+func (r *ErrorResponse) Error() string {
+	return fmt.Sprintf("%v %v: %v %v",
+		r.HttpResponse.Request.Method, r.HttpResponse.Request.URL,
+		r.HttpResponse.StatusCode, r.Message)
+}
+
+// CheckResponse checks the API response for errors, and returns them if present.
+// A response is considered an error if the status code is different than 2xx. Specific requests
+// may have additional requirements, but this is sufficient in most of the cases.
+func CheckResponse(resp *http.Response) error {
+	if code := resp.StatusCode; 200 <= code && code <= 299 {
+		return nil
+	}
+
+	errorResponse := &ErrorResponse{}
+	errorResponse.HttpResponse = resp
+
+	err := json.NewDecoder(resp.Body).Decode(errorResponse)
+	if err != nil {
+		return err
+	}
+
+	return errorResponse
+}
+
+// addOptions adds the parameters in opt as URL query parameters to s.  opt
+// must be a struct whose fields may contain "url" tags.
+func addURLQueryOptions(path string, options interface{}) (string, error) {
+	opt := reflect.ValueOf(options)
+
+	// options is a pointer
+	// return if the value of the pointer is nil,
+	if opt.Kind() == reflect.Ptr && opt.IsNil() {
+		return path, nil
+	}
+
+	// append the options to the URL
+	u, err := url.Parse(path)
+	if err != nil {
+		return path, err
+	}
+
+	qs, err := query.Values(options)
+	if err != nil {
+		return path, err
+	}
+
+	uqs := u.Query()
+	for k, _ := range qs {
+		uqs.Set(k, qs.Get(k))
+	}
+	u.RawQuery = uqs.Encode()
+
+	return u.String(), nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/domains.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/domains.go
@@ -1,0 +1,146 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// DomainsService handles communication with the domain related
+// methods of the DNSimple API.
+//
+// See https://developer.dnsimple.com/v2/domains/
+type DomainsService struct {
+	client *Client
+}
+
+// Domain represents a domain in DNSimple.
+type Domain struct {
+	ID           int    `json:"id,omitempty"`
+	AccountID    int    `json:"account_id,omitempty"`
+	RegistrantID int    `json:"registrant_id,omitempty"`
+	Name         string `json:"name,omitempty"`
+	UnicodeName  string `json:"unicode_name,omitempty"`
+	Token        string `json:"token,omitempty"`
+	State        string `json:"state,omitempty"`
+	AutoRenew    bool   `json:"auto_renew,omitempty"`
+	PrivateWhois bool   `json:"private_whois,omitempty"`
+	ExpiresOn    string `json:"expires_on,omitempty"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+}
+
+func domainPath(accountID string, domainIdentifier string) (path string) {
+	path = fmt.Sprintf("/%v/domains", accountID)
+	if domainIdentifier != "" {
+		path += fmt.Sprintf("/%v", domainIdentifier)
+	}
+	return
+}
+
+// domainResponse represents a response from an API method that returns a Domain struct.
+type domainResponse struct {
+	Response
+	Data *Domain `json:"data"`
+}
+
+// domainsResponse represents a response from an API method that returns a collection of Domain struct.
+type domainsResponse struct {
+	Response
+	Data []Domain `json:"data"`
+}
+
+// DomainListOptions specifies the optional parameters you can provide
+// to customize the DomainsService.ListDomains method.
+type DomainListOptions struct {
+	// Select domains where the name contains given string.
+	NameLike string `url:"name_like,omitempty"`
+
+	// Select domains where the registrant matches given ID.
+	RegistrantID int `url:"registrant_id,omitempty"`
+
+	ListOptions
+}
+
+// ListDomains lists the domains for an account.
+//
+// See https://developer.dnsimple.com/v2/domains/#list
+func (s *DomainsService) ListDomains(accountID string, options *DomainListOptions) (*domainsResponse, error) {
+	path := versioned(domainPath(accountID, ""))
+	domainsResponse := &domainsResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, domainsResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	domainsResponse.HttpResponse = resp
+	return domainsResponse, nil
+}
+
+// CreateDomain creates a new domain in the account.
+//
+// See https://developer.dnsimple.com/v2/domains/#create
+func (s *DomainsService) CreateDomain(accountID string, domainAttributes Domain) (*domainResponse, error) {
+	path := versioned(domainPath(accountID, ""))
+	domainResponse := &domainResponse{}
+
+	resp, err := s.client.post(path, domainAttributes, domainResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	domainResponse.HttpResponse = resp
+	return domainResponse, nil
+}
+
+// GetDomain fetches a domain.
+//
+// See https://developer.dnsimple.com/v2/domains/#get
+func (s *DomainsService) GetDomain(accountID string, domainIdentifier string) (*domainResponse, error) {
+	path := versioned(domainPath(accountID, domainIdentifier))
+	domainResponse := &domainResponse{}
+
+	resp, err := s.client.get(path, domainResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	domainResponse.HttpResponse = resp
+	return domainResponse, nil
+}
+
+// DeleteDomain PERMANENTLY deletes a domain from the account.
+//
+// See https://developer.dnsimple.com/v2/domains/#delete
+func (s *DomainsService) DeleteDomain(accountID string, domainIdentifier string) (*domainResponse, error) {
+	path := versioned(domainPath(accountID, domainIdentifier))
+	domainResponse := &domainResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	domainResponse.HttpResponse = resp
+	return domainResponse, nil
+}
+
+// ResetDomainToken resets the domain token.
+//
+// See https://developer.dnsimple.com/v2/domains/#reset-token
+func (s *DomainsService) ResetDomainToken(accountID string, domainIdentifier string) (*domainResponse, error) {
+	path := versioned(domainPath(accountID, domainIdentifier) + "/token")
+	domainResponse := &domainResponse{}
+
+	resp, err := s.client.post(path, nil, domainResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	domainResponse.HttpResponse = resp
+	return domainResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/domains_collaborators.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/domains_collaborators.go
@@ -1,0 +1,96 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// Collaborator represents a Collaborator in DNSimple.
+type Collaborator struct {
+	ID         int    `json:"id,omitempty"`
+	DomainID   int    `json:"domain_id,omitempty"`
+	DomainName string `json:"domain_name,omitempty"`
+	UserID     int    `json:"user_id,omitempty"`
+	UserEmail  string `json:"user_email,omitempty"`
+	Invitation bool   `json:"invitation,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
+	UpdatedAt  string `json:"updated_at,omitempty"`
+	AcceptedAt string `json:"accepted_at,omitempty"`
+}
+
+func collaboratorPath(accountID, domainIdentifier, collaboratorID string) (path string) {
+	path = fmt.Sprintf("%v/collaborators", domainPath(accountID, domainIdentifier))
+	if collaboratorID != "" {
+		path += fmt.Sprintf("/%v", collaboratorID)
+	}
+	return
+}
+
+// CollaboratorAttributes represents Collaborator attributes for AddCollaborator operation.
+type CollaboratorAttributes struct {
+	Email string `json:"email,omitempty"`
+}
+
+// collaboratorResponse represents a response from an API method that returns a Collaborator struct.
+type collaboratorResponse struct {
+	Response
+	Data *Collaborator `json:"data"`
+}
+
+// collaboratorsResponse represents a response from an API method that returns a collection of Collaborator struct.
+type collaboratorsResponse struct {
+	Response
+	Data []Collaborator `json:"data"`
+}
+
+// ListCollaborators list the collaborators for a domain.
+//
+// See https://developer.dnsimple.com/v2/domains/collaborators#list
+func (s *DomainsService) ListCollaborators(accountID, domainIdentifier string, options *ListOptions) (*collaboratorsResponse, error) {
+	path := versioned(collaboratorPath(accountID, domainIdentifier, ""))
+	collaboratorsResponse := &collaboratorsResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, collaboratorsResponse)
+	if err != nil {
+		return collaboratorsResponse, err
+	}
+
+	collaboratorsResponse.HttpResponse = resp
+	return collaboratorsResponse, nil
+}
+
+// AddCollaborator adds a new collaborator to the domain in the account.
+//
+// See https://developer.dnsimple.com/v2/domains/collaborators#add
+func (s *DomainsService) AddCollaborator(accountID string, domainIdentifier string, attributes CollaboratorAttributes) (*collaboratorResponse, error) {
+	path := versioned(collaboratorPath(accountID, domainIdentifier, ""))
+	collaboratorResponse := &collaboratorResponse{}
+
+	resp, err := s.client.post(path, attributes, collaboratorResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	collaboratorResponse.HttpResponse = resp
+	return collaboratorResponse, nil
+}
+
+// RemoveCollaborator PERMANENTLY deletes a domain from the account.
+//
+// See https://developer.dnsimple.com/v2/domains/collaborators#add
+func (s *DomainsService) RemoveCollaborator(accountID string, domainIdentifier string, collaboratorID string) (*collaboratorResponse, error) {
+	path := versioned(collaboratorPath(accountID, domainIdentifier, collaboratorID))
+	collaboratorResponse := &collaboratorResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	collaboratorResponse.HttpResponse = resp
+	return collaboratorResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/domains_delegation_signer_records.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/domains_delegation_signer_records.go
@@ -1,0 +1,105 @@
+package dnsimple
+
+import "fmt"
+
+// DelegationSignerRecord represents a delegation signer record for a domain in DNSimple.
+type DelegationSignerRecord struct {
+	ID         int    `json:"id,omitempty"`
+	DomainID   int    `json:"domain_id,omitempty"`
+	Algorithm  string `json:"algorithm"`
+	Digest     string `json:"digest"`
+	DigestType string `json:"digest_type"`
+	Keytag     string `json:"keytag"`
+	CreatedAt  string `json:"created_at,omitempty"`
+	UpdatedAt  string `json:"updated_at,omitempty"`
+}
+
+func delegationSignerRecordPath(accountID string, domainIdentifier string, dsRecordID int) (path string) {
+	path = fmt.Sprintf("%v/ds_records", domainPath(accountID, domainIdentifier))
+	if dsRecordID != 0 {
+		path += fmt.Sprintf("/%d", dsRecordID)
+	}
+	return
+}
+
+// delegationSignerRecordResponse represents a response from an API method that returns a DelegationSignerRecord struct.
+type delegationSignerRecordResponse struct {
+	Response
+	Data *DelegationSignerRecord `json:"data"`
+}
+
+// delegationSignerRecordResponse represents a response from an API method that returns a DelegationSignerRecord struct.
+type delegationSignerRecordsResponse struct {
+	Response
+	Data []DelegationSignerRecord `json:"data"`
+}
+
+// ListDelegationSignerRecords lists the delegation signer records for a domain.
+//
+// See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-list
+func (s *DomainsService) ListDelegationSignerRecords(accountID string, domainIdentifier string, options *ListOptions) (*delegationSignerRecordsResponse, error) {
+	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, 0))
+	dsRecordsResponse := &delegationSignerRecordsResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, dsRecordsResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	dsRecordsResponse.HttpResponse = resp
+	return dsRecordsResponse, nil
+}
+
+// CreateDelegationSignerRecord creates a new delegation signer record.
+//
+// See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-create
+func (s *DomainsService) CreateDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordAttributes DelegationSignerRecord) (*delegationSignerRecordResponse, error) {
+	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, 0))
+	dsRecordResponse := &delegationSignerRecordResponse{}
+
+	resp, err := s.client.post(path, dsRecordAttributes, dsRecordResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	dsRecordResponse.HttpResponse = resp
+	return dsRecordResponse, nil
+}
+
+// GetDelegationSignerRecord fetches a delegation signer record.
+//
+// See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-get
+func (s *DomainsService) GetDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordID int) (*delegationSignerRecordResponse, error) {
+	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID))
+	dsRecordResponse := &delegationSignerRecordResponse{}
+
+	resp, err := s.client.get(path, dsRecordResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	dsRecordResponse.HttpResponse = resp
+	return dsRecordResponse, nil
+}
+
+// DeleteDelegationSignerRecord PERMANENTLY deletes a delegation signer record
+// from the domain.
+//
+// See https://developer.dnsimple.com/v2/domains/dnssec/#ds-record-delete
+func (s *DomainsService) DeleteDelegationSignerRecord(accountID string, domainIdentifier string, dsRecordID int) (*delegationSignerRecordResponse, error) {
+	path := versioned(delegationSignerRecordPath(accountID, domainIdentifier, dsRecordID))
+	dsRecordResponse := &delegationSignerRecordResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	dsRecordResponse.HttpResponse = resp
+	return dsRecordResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/domains_dnssec.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/domains_dnssec.go
@@ -1,0 +1,68 @@
+package dnsimple
+
+import "fmt"
+
+// Dnssec represents the current DNSSEC settings for a domain in DNSimple.
+type Dnssec struct {
+	Enabled bool `json:"enabled"`
+}
+
+func dnssecPath(accountID string, domainIdentifier string) (path string) {
+	path = fmt.Sprintf("%v/dnssec", domainPath(accountID, domainIdentifier))
+	return
+}
+
+// dnssecResponse represents a response from an API method that returns a Dnssec struct.
+type dnssecResponse struct {
+	Response
+	Data *Dnssec `json:"data"`
+}
+
+// EnableDnssec enables DNSSEC on the domain.
+//
+// See https://developer.dnsimple.com/v2/domains/dnssec/#enable
+
+func (s *DomainsService) EnableDnssec(accountID string, domainIdentifier string) (*dnssecResponse, error) {
+	path := versioned(dnssecPath(accountID, domainIdentifier))
+	dnssecResponse := &dnssecResponse{}
+
+	resp, err := s.client.post(path, dnssecResponse, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	dnssecResponse.HttpResponse = resp
+	return dnssecResponse, nil
+}
+
+// DisableDnssec disables DNSSEC on the domain.
+//
+// See https://developer.dnsimple.com/v2/domains/dnssec/#disable
+func (s *DomainsService) DisableDnssec(accountID string, domainIdentifier string) (*dnssecResponse, error) {
+	path := versioned(dnssecPath(accountID, domainIdentifier))
+	dnssecResponse := &dnssecResponse{}
+
+	resp, err := s.client.delete(path, dnssecResponse, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	dnssecResponse.HttpResponse = resp
+	return dnssecResponse, nil
+}
+
+// GetDnssec retrieves the current status of DNSSEC on the domain.
+//
+// See https://developer.dnsimple.com/v2/domains/dnssec/#get
+func (s *DomainsService) GetDnssec(accountID string, domainIdentifier string) (*dnssecResponse, error) {
+	path := versioned(dnssecPath(accountID, domainIdentifier))
+	dnssecResponse := &dnssecResponse{}
+
+	resp, err := s.client.get(path, dnssecResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	dnssecResponse.HttpResponse = resp
+	return dnssecResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/domains_email_forwards.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/domains_email_forwards.go
@@ -1,0 +1,104 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// EmailForward represents an email forward in DNSimple.
+type EmailForward struct {
+	ID        int    `json:"id,omitempty"`
+	DomainID  int    `json:"domain_id,omitempty"`
+	From      string `json:"from,omitempty"`
+	To        string `json:"to,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+func emailForwardPath(accountID string, domainIdentifier string, forwardID int) (path string) {
+	path = fmt.Sprintf("%v/email_forwards", domainPath(accountID, domainIdentifier))
+	if forwardID != 0 {
+		path += fmt.Sprintf("/%d", forwardID)
+	}
+	return
+}
+
+// emailForwardResponse represents a response from an API method that returns an EmailForward struct.
+type emailForwardResponse struct {
+	Response
+	Data *EmailForward `json:"data"`
+}
+
+// emailForwardsResponse represents a response from an API method that returns a collection of EmailForward struct.
+type emailForwardsResponse struct {
+	Response
+	Data []EmailForward `json:"data"`
+}
+
+// ListEmailForwards lists the email forwards for a domain.
+//
+// See https://developer.dnsimple.com/v2/domains/email-forwards/#list
+func (s *DomainsService) ListEmailForwards(accountID string, domainIdentifier string, options *ListOptions) (*emailForwardsResponse, error) {
+	path := versioned(emailForwardPath(accountID, domainIdentifier, 0))
+	forwardsResponse := &emailForwardsResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, forwardsResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	forwardsResponse.HttpResponse = resp
+	return forwardsResponse, nil
+}
+
+// CreateEmailForward creates a new email forward.
+//
+// See https://developer.dnsimple.com/v2/domains/email-forwards/#create
+func (s *DomainsService) CreateEmailForward(accountID string, domainIdentifier string, forwardAttributes EmailForward) (*emailForwardResponse, error) {
+	path := versioned(emailForwardPath(accountID, domainIdentifier, 0))
+	forwardResponse := &emailForwardResponse{}
+
+	resp, err := s.client.post(path, forwardAttributes, forwardResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	forwardResponse.HttpResponse = resp
+	return forwardResponse, nil
+}
+
+// GetEmailForward fetches an email forward.
+//
+// See https://developer.dnsimple.com/v2/domains/email-forwards/#get
+func (s *DomainsService) GetEmailForward(accountID string, domainIdentifier string, forwardID int) (*emailForwardResponse, error) {
+	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
+	forwardResponse := &emailForwardResponse{}
+
+	resp, err := s.client.get(path, forwardResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	forwardResponse.HttpResponse = resp
+	return forwardResponse, nil
+}
+
+// DeleteEmailForward PERMANENTLY deletes an email forward from the domain.
+//
+// See https://developer.dnsimple.com/v2/domains/email-forwards/#delete
+func (s *DomainsService) DeleteEmailForward(accountID string, domainIdentifier string, forwardID int) (*emailForwardResponse, error) {
+	path := versioned(emailForwardPath(accountID, domainIdentifier, forwardID))
+	forwardResponse := &emailForwardResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	forwardResponse.HttpResponse = resp
+	return forwardResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/domains_pushes.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/domains_pushes.go
@@ -1,0 +1,111 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// DomainPush represents a domain push in DNSimple.
+type DomainPush struct {
+	ID         int    `json:"id,omitempty"`
+	DomainID   int    `json:"domain_id,omitempty"`
+	ContactID  int    `json:"contact_id,omitempty"`
+	AccountID  int    `json:"account_id,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
+	UpdatedAt  string `json:"updated_at,omitempty"`
+	AcceptedAt string `json:"accepted_at,omitempty"`
+}
+
+func domainPushPath(accountID string, pushID int) (path string) {
+	path = fmt.Sprintf("/%v/pushes", accountID)
+	if pushID != 0 {
+		path += fmt.Sprintf("/%d", pushID)
+	}
+	return
+}
+
+// domainPushResponse represents a response from an API method that returns a DomainPush struct.
+type domainPushResponse struct {
+	Response
+	Data *DomainPush `json:"data"`
+}
+
+// domainPushesResponse represents a response from an API method that returns a collection of DomainPush struct.
+type domainPushesResponse struct {
+	Response
+	Data []DomainPush `json:"data"`
+}
+
+// DomainPushAttributes represent a domain push payload (see initiate).
+type DomainPushAttributes struct {
+	NewAccountEmail string `json:"new_account_email,omitempty"`
+	ContactID       string `json:"contact_id,omitempty"`
+}
+
+// InitiatePush initiate a new domain push.
+//
+// See https://developer.dnsimple.com/v2/domains/pushes/#initiate
+func (s *DomainsService) InitiatePush(accountID string, domainID string, pushAttributes DomainPushAttributes) (*domainPushResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/pushes", domainPath(accountID, domainID)))
+	pushResponse := &domainPushResponse{}
+
+	resp, err := s.client.post(path, pushAttributes, pushResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	pushResponse.HttpResponse = resp
+	return pushResponse, nil
+}
+
+// ListPushes lists the pushes for an account.
+//
+// See https://developer.dnsimple.com/v2/domains/pushes/#list
+func (s *DomainsService) ListPushes(accountID string, options *ListOptions) (*domainPushesResponse, error) {
+	path := versioned(domainPushPath(accountID, 0))
+	pushesResponse := &domainPushesResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, pushesResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	pushesResponse.HttpResponse = resp
+	return pushesResponse, nil
+}
+
+// AcceptPush accept a push for a domain.
+//
+// See https://developer.dnsimple.com/v2/domains/pushes/#accept
+func (s *DomainsService) AcceptPush(accountID string, pushID int, pushAttributes DomainPushAttributes) (*domainPushResponse, error) {
+	path := versioned(domainPushPath(accountID, pushID))
+	pushResponse := &domainPushResponse{}
+
+	resp, err := s.client.post(path, pushAttributes, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	pushResponse.HttpResponse = resp
+	return pushResponse, nil
+}
+
+// RejectPush reject a push for a domain.
+//
+// See https://developer.dnsimple.com/v2/domains/pushes/#reject
+func (s *DomainsService) RejectPush(accountID string, pushID int) (*domainPushResponse, error) {
+	path := versioned(domainPushPath(accountID, pushID))
+	pushResponse := &domainPushResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	pushResponse.HttpResponse = resp
+	return pushResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/identity.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/identity.go
@@ -1,0 +1,48 @@
+package dnsimple
+
+// IdentityService handles communication with several authentication identity
+// methods of the DNSimple API.
+//
+// See https://developer.dnsimple.com/v2/identity/
+type IdentityService struct {
+	client *Client
+}
+
+// WhoamiData represents an authenticated context
+// that contains information about the current logged User and/or Account.
+type WhoamiData struct {
+	User    *User    `json:"user,omitempty"`
+	Account *Account `json:"account,omitempty"`
+}
+
+// whoamiResponse represents a response from an API method that returns a Whoami struct.
+type whoamiResponse struct {
+	Response
+	Data *WhoamiData `json:"data"`
+}
+
+// Whoami gets the current authenticate context.
+//
+// See https://developer.dnsimple.com/v2/whoami
+func (s *IdentityService) Whoami() (*whoamiResponse, error) {
+	path := versioned("/whoami")
+	whoamiResponse := &whoamiResponse{}
+
+	resp, err := s.client.get(path, whoamiResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	whoamiResponse.HttpResponse = resp
+	return whoamiResponse, nil
+}
+
+// Whoami is a state-less shortcut to client.Whoami()
+// that returns only the relevant Data.
+func Whoami(c *Client) (data *WhoamiData, err error) {
+	resp, err := c.Identity.Whoami()
+	if resp != nil {
+		data = resp.Data
+	}
+	return
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/oauth.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/oauth.go
@@ -1,0 +1,113 @@
+package dnsimple
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// GrantType is a string that identifies a particular grant type in the exchange request.
+type GrantType string
+
+const (
+	// AuthorizationCodeGrant is the type of access token request
+	// for an Authorization Code Grant flow.
+	// https://tools.ietf.org/html/rfc6749#section-4.1
+	AuthorizationCodeGrant = GrantType("authorization_code")
+)
+
+// OauthService handles communication with the authorization related
+// methods of the DNSimple API.
+//
+// See https://developer.dnsimple.com/v2/oauth/
+type OauthService struct {
+	client *Client
+}
+
+// AccessToken represents a DNSimple Oauth access token.
+type AccessToken struct {
+	Token     string `json:"access_token"`
+	Type      string `json:"token_type"`
+	AccountID int    `json:"account_id"`
+}
+
+// ExchangeAuthorizationRequest represents a request to exchange
+// an authorization code for an access token.
+// RedirectURI is optional, all the other fields are mandatory.
+type ExchangeAuthorizationRequest struct {
+	Code         string    `json:"code"`
+	ClientID     string    `json:"client_id"`
+	ClientSecret string    `json:"client_secret"`
+	RedirectURI  string    `json:"redirect_uri,omitempty"`
+	State        string    `json:"state,omitempty"`
+	GrantType    GrantType `json:"grant_type,omitempty"`
+}
+
+// ExchangeAuthorizationError represents a failed request to exchange
+// an authorization code for an access token.
+type ExchangeAuthorizationError struct {
+	// HTTP response
+	HttpResponse *http.Response
+
+	ErrorCode        string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// Error implements the error interface.
+func (r *ExchangeAuthorizationError) Error() string {
+	return fmt.Sprintf("%v %v: %v %v",
+		r.HttpResponse.Request.Method, r.HttpResponse.Request.URL,
+		r.ErrorCode, r.ErrorDescription)
+}
+
+// ExchangeAuthorizationForToken exchanges the short-lived authorization code for an access token
+// you can use to authenticate your API calls.
+func (s *OauthService) ExchangeAuthorizationForToken(authorization *ExchangeAuthorizationRequest) (*AccessToken, error) {
+	path := versioned("/oauth/access_token")
+
+	req, err := s.client.NewRequest("POST", path, authorization)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.HttpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		errorResponse := &ExchangeAuthorizationError{}
+		errorResponse.HttpResponse = resp
+		json.NewDecoder(resp.Body).Decode(errorResponse)
+		return nil, errorResponse
+	}
+
+	accessToken := &AccessToken{}
+	err = json.NewDecoder(resp.Body).Decode(accessToken)
+
+	return accessToken, err
+}
+
+// AuthorizationOptions represents the option you can use to generate an authorization URL.
+type AuthorizationOptions struct {
+	RedirectURI string `url:"redirect_uri,omitempty"`
+	// A randomly generated string to verify the validity of the request.
+	// Currently "state" is required by the DNSimple OAuth implementation, so you must specify it.
+	State string `url:"state,omitempty"`
+}
+
+// AuthorizeURL generates the URL to authorize an user for an application via the OAuth2 flow.
+func (s *OauthService) AuthorizeURL(clientID string, options *AuthorizationOptions) string {
+	uri, _ := url.Parse(strings.Replace(s.client.BaseURL, "api.", "", 1))
+	uri.Path = "/oauth/authorize"
+	query := uri.Query()
+	query.Add("client_id", clientID)
+	query.Add("response_type", "code")
+	uri.RawQuery = query.Encode()
+
+	path, _ := addURLQueryOptions(uri.String(), options)
+	return path
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/registrar.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/registrar.go
@@ -1,0 +1,258 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// RegistrarService handles communication with the registrar related
+// methods of the DNSimple API.
+//
+// See https://developer.dnsimple.com/v2/registrar/
+type RegistrarService struct {
+	client *Client
+}
+
+// DomainCheck represents the result of a domain check.
+type DomainCheck struct {
+	Domain    string `json:"domain"`
+	Available bool   `json:"available"`
+	Premium   bool   `json:"premium"`
+}
+
+// domainCheckResponse represents a response from a domain check request.
+type domainCheckResponse struct {
+	Response
+	Data *DomainCheck `json:"data"`
+}
+
+// CheckDomain checks a domain name.
+//
+// See https://developer.dnsimple.com/v2/registrar/#check
+func (s *RegistrarService) CheckDomain(accountID, domainName string) (*domainCheckResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/check", accountID, domainName))
+	checkResponse := &domainCheckResponse{}
+
+	resp, err := s.client.get(path, checkResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	checkResponse.HttpResponse = resp
+	return checkResponse, nil
+}
+
+// DomainPremiumPrice represents the premium price for a premium domain.
+type DomainPremiumPrice struct {
+	// The domain premium price
+	PremiumPrice string `json:"premium_price"`
+	// The registrar action.
+	// Possible values are registration|transfer|renewal
+	Action string `json:"action"`
+}
+
+// domainPremiumPriceResponse represents a response from a domain premium price request.
+type domainPremiumPriceResponse struct {
+	Response
+	Data *DomainPremiumPrice `json:"data"`
+}
+
+// DomainPremiumPriceOptions specifies the optional parameters you can provide
+// to customize the RegistrarService.GetDomainPremiumPrice method.
+type DomainPremiumPriceOptions struct {
+	Action string `url:"action,omitempty"`
+}
+
+// Gets the premium price for a domain.
+//
+// You must specify an action to get the price for. Valid actions are:
+// - registration
+// - transfer
+// - renewal
+//
+// See https://developer.dnsimple.com/v2/registrar/#premium-price
+func (s *RegistrarService) GetDomainPremiumPrice(accountID, domainName string, options *DomainPremiumPriceOptions) (*domainPremiumPriceResponse, error) {
+	var err error
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/premium_price", accountID, domainName))
+	priceResponse := &domainPremiumPriceResponse{}
+
+	if options != nil {
+		path, err = addURLQueryOptions(path, options)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	resp, err := s.client.get(path, priceResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	priceResponse.HttpResponse = resp
+	return priceResponse, nil
+}
+
+// DomainRegistration represents the result of a domain renewal call.
+type DomainRegistration struct {
+	ID           int    `json:"id"`
+	DomainID     int    `json:"domain_id"`
+	RegistrantID int    `json:"registrant_id"`
+	Period       int    `json:"period"`
+	State        string `json:"state"`
+	AutoRenew    bool   `json:"auto_renew"`
+	WhoisPrivacy bool   `json:"whois_privacy"`
+	PremiumPrice string `json:"premium_price"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+}
+
+// domainRegistrationResponse represents a response from an API method that results in a domain registration.
+type domainRegistrationResponse struct {
+	Response
+	Data *DomainRegistration `json:"data"`
+}
+
+// DomainRegisterRequest represents the attributes you can pass to a register API request.
+// Some attributes are mandatory.
+type DomainRegisterRequest struct {
+	// The ID of the Contact to use as registrant for the domain
+	RegistrantID int `json:"registrant_id"`
+	// Set to true to enable the whois privacy service. An extra cost may apply.
+	// Default to false.
+	EnableWhoisPrivacy bool `json:"whois_privacy,omitempty"`
+	// Set to true to enable the auto-renewal of the domain.
+	// Default to true.
+	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
+}
+
+// RegisterDomain registers a domain name.
+//
+// See https://developer.dnsimple.com/v2/registrar/#register
+func (s *RegistrarService) RegisterDomain(accountID string, domainName string, request *DomainRegisterRequest) (*domainRegistrationResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/registrations", accountID, domainName))
+	registrationResponse := &domainRegistrationResponse{}
+
+	// TODO: validate mandatory attributes RegistrantID
+
+	resp, err := s.client.post(path, request, registrationResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	registrationResponse.HttpResponse = resp
+	return registrationResponse, nil
+}
+
+// DomainTransfer represents the result of a domain renewal call.
+type DomainTransfer struct {
+	ID           int    `json:"id"`
+	DomainID     int    `json:"domain_id"`
+	RegistrantID int    `json:"registrant_id"`
+	State        string `json:"state"`
+	AutoRenew    bool   `json:"auto_renew"`
+	WhoisPrivacy bool   `json:"whois_privacy"`
+	PremiumPrice string `json:"premium_price"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+}
+
+// domainTransferResponse represents a response from an API method that results in a domain transfer.
+type domainTransferResponse struct {
+	Response
+	Data *DomainTransfer `json:"data"`
+}
+
+// DomainTransferRequest represents the attributes you can pass to a transfer API request.
+// Some attributes are mandatory.
+type DomainTransferRequest struct {
+	// The ID of the Contact to use as registrant for the domain
+	RegistrantID int `json:"registrant_id"`
+	// The Auth-Code required to transfer the domain.
+	// This is provided by the current registrar of the domain.
+	AuthCode string `json:"auth_code,omitempty"`
+	// Set to true to enable the whois privacy service. An extra cost may apply.
+	// Default to false.
+	EnableWhoisPrivacy bool `json:"whois_privacy,omitempty"`
+	// Set to true to enable the auto-renewal of the domain.
+	// Default to true.
+	EnableAutoRenewal bool `json:"auto_renew,omitempty"`
+}
+
+// TransferDomain transfers a domain name.
+//
+// See https://developer.dnsimple.com/v2/registrar/#transfer
+func (s *RegistrarService) TransferDomain(accountID string, domainName string, request *DomainTransferRequest) (*domainTransferResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/transfers", accountID, domainName))
+	transferResponse := &domainTransferResponse{}
+
+	// TODO: validate mandatory attributes RegistrantID
+
+	resp, err := s.client.post(path, request, transferResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	transferResponse.HttpResponse = resp
+	return transferResponse, nil
+}
+
+// domainTransferOutResponse represents a response from an API method that results in a domain transfer out.
+type domainTransferOutResponse struct {
+	Response
+	Data *Domain `json:"data"`
+}
+
+// Transfer out a domain name.
+//
+// See https://developer.dnsimple.com/v2/registrar/#transfer-out
+func (s *RegistrarService) TransferDomainOut(accountID string, domainName string) (*domainTransferOutResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/authorize_transfer_out", accountID, domainName))
+	transferResponse := &domainTransferOutResponse{}
+
+	resp, err := s.client.post(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	transferResponse.HttpResponse = resp
+	return transferResponse, nil
+}
+
+// DomainRenewal represents the result of a domain renewal call.
+type DomainRenewal struct {
+	ID           int    `json:"id"`
+	DomainID     int    `json:"domain_id"`
+	Period       int    `json:"period"`
+	State        string `json:"state"`
+	PremiumPrice string `json:"premium_price"`
+	CreatedAt    string `json:"created_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+}
+
+// domainRenewalResponse represents a response from an API method that returns a domain renewal.
+type domainRenewalResponse struct {
+	Response
+	Data *DomainRenewal `json:"data"`
+}
+
+// DomainRenewRequest represents the attributes you can pass to a renew API request.
+// Some attributes are mandatory.
+type DomainRenewRequest struct {
+	// The number of years
+	Period int `json:"period"`
+}
+
+// RenewDomain renews a domain name.
+//
+// See https://developer.dnsimple.com/v2/registrar/#register
+func (s *RegistrarService) RenewDomain(accountID string, domainName string, request *DomainRenewRequest) (*domainRenewalResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/renewals", accountID, domainName))
+	renewalResponse := &domainRenewalResponse{}
+
+	resp, err := s.client.post(path, request, renewalResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	renewalResponse.HttpResponse = resp
+	return renewalResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/registrar_auto_renewal.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/registrar_auto_renewal.go
@@ -1,0 +1,37 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// EnableDomainAutoRenewal enables auto-renewal for the domain.
+//
+// See https://developer.dnsimple.com/v2/registrar/auto-renewal/#enable
+func (s *RegistrarService) EnableDomainAutoRenewal(accountID string, domainName string) (*domainResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/auto_renewal", accountID, domainName))
+	domainResponse := &domainResponse{}
+
+	resp, err := s.client.put(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	domainResponse.HttpResponse = resp
+	return domainResponse, nil
+}
+
+// DisableDomainAutoRenewal disables auto-renewal for the domain.
+//
+// See https://developer.dnsimple.com/v2/registrar/auto-renewal/#enable
+func (s *RegistrarService) DisableDomainAutoRenewal(accountID string, domainName string) (*domainResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/auto_renewal", accountID, domainName))
+	domainResponse := &domainResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	domainResponse.HttpResponse = resp
+	return domainResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/registrar_delegation.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/registrar_delegation.go
@@ -1,0 +1,84 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// Delegation represents a list of name servers that correspond to a domain delegation.
+type Delegation []string
+
+// delegationResponse represents a response from an API method that returns a delegation struct.
+type delegationResponse struct {
+	Response
+	Data *Delegation `json:"data"`
+}
+
+// vanityDelegationResponse represents a response for vanity name server enable and disable operations.
+type vanityDelegationResponse struct {
+	Response
+	Data []VanityNameServer `json:"data"`
+}
+
+// GetDomainDelegation gets the current delegated name servers for the domain.
+//
+// See https://developer.dnsimple.com/v2/registrar/delegation/#get
+func (s *RegistrarService) GetDomainDelegation(accountID string, domainName string) (*delegationResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation", accountID, domainName))
+	delegationResponse := &delegationResponse{}
+
+	resp, err := s.client.get(path, delegationResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	delegationResponse.HttpResponse = resp
+	return delegationResponse, nil
+}
+
+// ChangeDomainDelegation updates the delegated name severs for the domain.
+//
+// See https://developer.dnsimple.com/v2/registrar/delegation/#get
+func (s *RegistrarService) ChangeDomainDelegation(accountID string, domainName string, newDelegation *Delegation) (*delegationResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation", accountID, domainName))
+	delegationResponse := &delegationResponse{}
+
+	resp, err := s.client.put(path, newDelegation, delegationResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	delegationResponse.HttpResponse = resp
+	return delegationResponse, nil
+}
+
+// ChangeDomainDelegationToVanity enables vanity name servers for the given domain.
+//
+// See https://developer.dnsimple.com/v2/registrar/delegation/#delegateToVanity
+func (s *RegistrarService) ChangeDomainDelegationToVanity(accountID string, domainName string, newDelegation *Delegation) (*vanityDelegationResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation/vanity", accountID, domainName))
+	delegationResponse := &vanityDelegationResponse{}
+
+	resp, err := s.client.put(path, newDelegation, delegationResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	delegationResponse.HttpResponse = resp
+	return delegationResponse, nil
+}
+
+// ChangeDomainDelegationFromVanity disables vanity name servers for the given domain.
+//
+// See https://developer.dnsimple.com/v2/registrar/delegation/#dedelegateFromVanity
+func (s *RegistrarService) ChangeDomainDelegationFromVanity(accountID string, domainName string) (*vanityDelegationResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/delegation/vanity", accountID, domainName))
+	delegationResponse := &vanityDelegationResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	delegationResponse.HttpResponse = resp
+	return delegationResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/registrar_whois_privacy.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/registrar_whois_privacy.go
@@ -1,0 +1,69 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// WhoisPrivacy represents a whois privacy in DNSimple.
+type WhoisPrivacy struct {
+	ID        int    `json:"id,omitempty"`
+	DomainID  int    `json:"domain_id,omitempty"`
+	Enabled   bool   `json:"enabled,omitempty"`
+	ExpiresOn string `json:"expires_on,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// whoisPrivacyResponse represents a response from an API method that returns a WhoisPrivacy struct.
+type whoisPrivacyResponse struct {
+	Response
+	Data *WhoisPrivacy `json:"data"`
+}
+
+// GetWhoisPrivacy gets the whois privacy for the domain.
+//
+// See https://developer.dnsimple.com/v2/registrar/whois-privacy/#get
+func (s *RegistrarService) GetWhoisPrivacy(accountID string, domainName string) (*whoisPrivacyResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
+	privacyResponse := &whoisPrivacyResponse{}
+
+	resp, err := s.client.get(path, privacyResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	privacyResponse.HttpResponse = resp
+	return privacyResponse, nil
+}
+
+// EnableWhoisPrivacy enables the whois privacy for the domain.
+//
+// See https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable
+func (s *RegistrarService) EnableWhoisPrivacy(accountID string, domainName string) (*whoisPrivacyResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
+	privacyResponse := &whoisPrivacyResponse{}
+
+	resp, err := s.client.put(path, nil, privacyResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	privacyResponse.HttpResponse = resp
+	return privacyResponse, nil
+}
+
+// DisablePrivacy disables the whois privacy for the domain.
+//
+// See https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable
+func (s *RegistrarService) DisableWhoisPrivacy(accountID string, domainName string) (*whoisPrivacyResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/registrar/domains/%v/whois_privacy", accountID, domainName))
+	privacyResponse := &whoisPrivacyResponse{}
+
+	resp, err := s.client.delete(path, nil, privacyResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	privacyResponse.HttpResponse = resp
+	return privacyResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/services.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/services.go
@@ -1,0 +1,94 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// ServicesService handles communication with the service related
+// methods of the DNSimple API.
+//
+// See https://developer.dnsimple.com/v2/services/
+type ServicesService struct {
+	client *Client
+}
+
+// Service represents a Service in DNSimple.
+type Service struct {
+	ID               int              `json:"id,omitempty"`
+	SID              string           `json:"sid,omitempty"`
+	Name             string           `json:"name,omitempty"`
+	Description      string           `json:"description,omitempty"`
+	SetupDescription string           `json:"setup_description,omitempty"`
+	RequiresSetup    bool             `json:"requires_setup,omitempty"`
+	DefaultSubdomain string           `json:"default_subdomain,omitempty"`
+	CreatedAt        string           `json:"created_at,omitempty"`
+	UpdatedAt        string           `json:"updated_at,omitempty"`
+	Settings         []ServiceSetting `json:"settings,omitempty"`
+}
+
+// ServiceSetting represents a single group of settings for a DNSimple Service.
+type ServiceSetting struct {
+	Name        string `json:"name,omitempty"`
+	Label       string `json:"label,omitempty"`
+	Append      string `json:"append,omitempty"`
+	Description string `json:"description,omitempty"`
+	Example     string `json:"example,omitempty"`
+	Password    bool   `json:"password,omitempty"`
+}
+
+func servicePath(serviceID string) (path string) {
+	path = "/services"
+	if serviceID != "" {
+		path += fmt.Sprintf("/%v", serviceID)
+	}
+	return
+}
+
+// serviceResponse represents a response from an API method that returns a Service struct.
+type serviceResponse struct {
+	Response
+	Data *Service `json:"data"`
+}
+
+// servicesResponse represents a response from an API method that returns a collection of Service struct.
+type servicesResponse struct {
+	Response
+	Data []Service `json:"data"`
+}
+
+// ListServices lists the one-click services available in DNSimple.
+//
+// See https://developer.dnsimple.com/v2/services/#list
+func (s *ServicesService) ListServices(options *ListOptions) (*servicesResponse, error) {
+	path := versioned(servicePath(""))
+	servicesResponse := &servicesResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, servicesResponse)
+	if err != nil {
+		return servicesResponse, err
+	}
+
+	servicesResponse.HttpResponse = resp
+	return servicesResponse, nil
+}
+
+// GetService fetches a one-click service.
+//
+// See https://developer.dnsimple.com/v2/services/#get
+func (s *ServicesService) GetService(serviceIdentifier string) (*serviceResponse, error) {
+	path := versioned(servicePath(serviceIdentifier))
+	serviceResponse := &serviceResponse{}
+
+	resp, err := s.client.get(path, serviceResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceResponse.HttpResponse = resp
+	return serviceResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/services_domains.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/services_domains.go
@@ -1,0 +1,70 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+func domainServicesPath(accountID string, domainID string, serviceIdentifier string) string {
+	if serviceIdentifier != "" {
+		return fmt.Sprintf("/%v/domains/%v/services/%v", accountID, domainID, serviceIdentifier)
+	}
+	return fmt.Sprintf("/%v/domains/%v/services", accountID, domainID)
+}
+
+// DomainServiceSettings represents optional settings when applying a DNSimple one-click service to a domain.
+type DomainServiceSettings struct {
+	Settings map[string]string `url:"settings,omitempty"`
+}
+
+// AppliedServices lists the applied one-click services for a domain.
+//
+// See https://developer.dnsimple.com/v2/services/domains/#applied
+func (s *ServicesService) AppliedServices(accountID string, domainID string, options *ListOptions) (*servicesResponse, error) {
+	path := versioned(domainServicesPath(accountID, domainID, ""))
+	servicesResponse := &servicesResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, servicesResponse)
+	if err != nil {
+		return servicesResponse, err
+	}
+
+	servicesResponse.HttpResponse = resp
+	return servicesResponse, nil
+}
+
+// ApplyService applies a one-click services to a domain.
+//
+// See https://developer.dnsimple.com/v2/services/domains/#apply
+func (s *ServicesService) ApplyService(accountID string, serviceIdentifier string, domainID string, settings DomainServiceSettings) (*serviceResponse, error) {
+	path := versioned(domainServicesPath(accountID, domainID, serviceIdentifier))
+	serviceResponse := &serviceResponse{}
+
+	resp, err := s.client.post(path, settings, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceResponse.HttpResponse = resp
+	return serviceResponse, nil
+}
+
+// UnapplyService unapplies a one-click services from a domain.
+//
+// See https://developer.dnsimple.com/v2/services/domains/#unapply
+func (s *ServicesService) UnapplyService(accountID string, serviceIdentifier string, domainID string) (*serviceResponse, error) {
+	path := versioned(domainServicesPath(accountID, domainID, serviceIdentifier))
+	serviceResponse := &serviceResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceResponse.HttpResponse = resp
+	return serviceResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/templates.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/templates.go
@@ -1,0 +1,129 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// TemplatesService handles communication with the template related
+// methods of the DNSimple API.
+//
+// See https://developer.dnsimple.com/v2/templates/
+type TemplatesService struct {
+	client *Client
+}
+
+// Template represents a Template in DNSimple.
+type Template struct {
+	ID          int    `json:"id,omitempty"`
+	SID         string `json:"sid,omitempty"`
+	AccountID   int    `json:"account_id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"`
+}
+
+func templatePath(accountID string, templateIdentifier string) (path string) {
+	path = fmt.Sprintf("/%v/templates", accountID)
+	if templateIdentifier != "" {
+		path += fmt.Sprintf("/%v", templateIdentifier)
+	}
+	return
+}
+
+// templateResponse represents a response from an API method that returns a Template struct.
+type templateResponse struct {
+	Response
+	Data *Template `json:"data"`
+}
+
+// templatesResponse represents a response from an API method that returns a collection of Template struct.
+type templatesResponse struct {
+	Response
+	Data []Template `json:"data"`
+}
+
+// ListTemplates list the templates for an account.
+//
+// See https://developer.dnsimple.com/v2/templates/#list
+func (s *TemplatesService) ListTemplates(accountID string, options *ListOptions) (*templatesResponse, error) {
+	path := versioned(templatePath(accountID, ""))
+	templatesResponse := &templatesResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, templatesResponse)
+	if err != nil {
+		return templatesResponse, err
+	}
+
+	templatesResponse.HttpResponse = resp
+	return templatesResponse, nil
+}
+
+// CreateTemplate creates a new template.
+//
+// See https://developer.dnsimple.com/v2/templates/#create
+func (s *TemplatesService) CreateTemplate(accountID string, templateAttributes Template) (*templateResponse, error) {
+	path := versioned(templatePath(accountID, ""))
+	templateResponse := &templateResponse{}
+
+	resp, err := s.client.post(path, templateAttributes, templateResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	templateResponse.HttpResponse = resp
+	return templateResponse, nil
+}
+
+// GetTemplate fetches a template.
+//
+// See https://developer.dnsimple.com/v2/templates/#get
+func (s *TemplatesService) GetTemplate(accountID string, templateIdentifier string) (*templateResponse, error) {
+	path := versioned(templatePath(accountID, templateIdentifier))
+	templateResponse := &templateResponse{}
+
+	resp, err := s.client.get(path, templateResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	templateResponse.HttpResponse = resp
+	return templateResponse, nil
+}
+
+// UpdateTemplate updates a template.
+//
+// See https://developer.dnsimple.com/v2/templates/#update
+func (s *TemplatesService) UpdateTemplate(accountID string, templateIdentifier string, templateAttributes Template) (*templateResponse, error) {
+	path := versioned(templatePath(accountID, templateIdentifier))
+	templateResponse := &templateResponse{}
+
+	resp, err := s.client.patch(path, templateAttributes, templateResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	templateResponse.HttpResponse = resp
+	return templateResponse, nil
+}
+
+// DeleteTemplate deletes a template.
+//
+// See https://developer.dnsimple.com/v2/templates/#delete
+func (s *TemplatesService) DeleteTemplate(accountID string, templateIdentifier string) (*templateResponse, error) {
+	path := versioned(templatePath(accountID, templateIdentifier))
+	templateResponse := &templateResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	templateResponse.HttpResponse = resp
+	return templateResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/templates_domains.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/templates_domains.go
@@ -1,0 +1,21 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// ApplyTemplate applies a template to the given domain.
+//
+// See https://developer.dnsimple.com/v2/templates/domains/#apply
+func (s *TemplatesService) ApplyTemplate(accountID string, templateIdentifier string, domainID string) (*templateResponse, error) {
+	path := versioned(fmt.Sprintf("%v/templates/%v", domainPath(accountID, domainID), templateIdentifier))
+	templateResponse := &templateResponse{}
+
+	resp, err := s.client.post(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	templateResponse.HttpResponse = resp
+	return templateResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/templates_records.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/templates_records.go
@@ -1,0 +1,107 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// TemplateRecord represents a DNS record for a template in DNSimple.
+type TemplateRecord struct {
+	ID         int    `json:"id,omitempty"`
+	TemplateID int    `json:"template_id,omitempty"`
+	Name       string `json:"name"`
+	Content    string `json:"content,omitempty"`
+	TTL        int    `json:"ttl,omitempty"`
+	Type       string `json:"type,omitempty"`
+	Priority   int    `json:"priority,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
+	UpdatedAt  string `json:"updated_at,omitempty"`
+}
+
+func templateRecordPath(accountID string, templateIdentifier string, templateRecordID string) string {
+	if templateRecordID != "" {
+		return fmt.Sprintf("%v/records/%v", templatePath(accountID, templateIdentifier), templateRecordID)
+	}
+
+	return templatePath(accountID, templateIdentifier) + "/records"
+}
+
+// templateRecordResponse represents a response from an API method that returns a TemplateRecord struct.
+type templateRecordResponse struct {
+	Response
+	Data *TemplateRecord `json:"data"`
+}
+
+// templateRecordsResponse represents a response from an API method that returns a collection of TemplateRecord struct.
+type templateRecordsResponse struct {
+	Response
+	Data []TemplateRecord `json:"data"`
+}
+
+// ListTemplateRecords list the templates for an account.
+//
+// See https://developer.dnsimple.com/v2/templates/records/#list
+func (s *TemplatesService) ListTemplateRecords(accountID string, templateIdentifier string, options *ListOptions) (*templateRecordsResponse, error) {
+	path := versioned(templateRecordPath(accountID, templateIdentifier, ""))
+	templateRecordsResponse := &templateRecordsResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, templateRecordsResponse)
+	if err != nil {
+		return templateRecordsResponse, err
+	}
+
+	templateRecordsResponse.HttpResponse = resp
+	return templateRecordsResponse, nil
+}
+
+// CreateTemplateRecord creates a new template record.
+//
+// See https://developer.dnsimple.com/v2/templates/records/#create
+func (s *TemplatesService) CreateTemplateRecord(accountID string, templateIdentifier string, templateRecordAttributes TemplateRecord) (*templateRecordResponse, error) {
+	path := versioned(templateRecordPath(accountID, templateIdentifier, ""))
+	templateRecordResponse := &templateRecordResponse{}
+
+	resp, err := s.client.post(path, templateRecordAttributes, templateRecordResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	templateRecordResponse.HttpResponse = resp
+	return templateRecordResponse, nil
+}
+
+// GetTemplateRecord fetches a template record.
+//
+// See https://developer.dnsimple.com/v2/templates/records/#get
+func (s *TemplatesService) GetTemplateRecord(accountID string, templateIdentifier string, templateRecordID string) (*templateRecordResponse, error) {
+	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
+	templateRecordResponse := &templateRecordResponse{}
+
+	resp, err := s.client.get(path, templateRecordResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	templateRecordResponse.HttpResponse = resp
+	return templateRecordResponse, nil
+}
+
+// DeleteTemplateRecord deletes a template record.
+//
+// See https://developer.dnsimple.com/v2/templates/records/#delete
+func (s *TemplatesService) DeleteTemplateRecord(accountID string, templateIdentifier string, templateRecordID string) (*templateRecordResponse, error) {
+	path := versioned(templateRecordPath(accountID, templateIdentifier, templateRecordID))
+	templateRecordResponse := &templateRecordResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	templateRecordResponse.HttpResponse = resp
+	return templateRecordResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/tlds.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/tlds.go
@@ -1,0 +1,117 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// TldsService handles communication with the Tld related
+// methods of the DNSimple API.
+//
+// See https://developer.dnsimple.com/v2/tlds/
+type TldsService struct {
+	client *Client
+}
+
+// Tld represents a TLD in DNSimple.
+type Tld struct {
+	Tld                 string `json:"tld"`
+	TldType             int    `json:"tld_type"`
+	WhoisPrivacy        bool   `json:"whois_privacy"`
+	AutoRenewOnly       bool   `json:"auto_renew_only"`
+	MinimumRegistration int    `json:"minimum_registration"`
+	RegistrationEnabled bool   `json:"registration_enabled"`
+	RenewalEnabled      bool   `json:"renewal_enabled"`
+	TransferEnabled     bool   `json:"transfer_enabled"`
+}
+
+// TldExtendedAttribute represents an extended attributes supported or required
+// by a specific TLD.
+//
+// See https://developer.dnsimple.com/v2/tlds/
+type TldExtendedAttribute struct {
+	Name        string                       `json:"name"`
+	Description string                       `json:"description"`
+	Required    bool                         `json:"required"`
+	Options     []TldExtendedAttributeOption `json:"options"`
+}
+
+// TldExtendedAttributeOption represents a single option you can assign to an extended attributes.
+//
+// See https://developer.dnsimple.com/v2/tlds/
+type TldExtendedAttributeOption struct {
+	Title       string `json:"title"`
+	Value       string `json:"value"`
+	Description string `json:"description"`
+}
+
+// tldResponse represents a response from an API method that returns a Tld struct.
+type tldResponse struct {
+	Response
+	Data *Tld `json:"data"`
+}
+
+// tldsResponse represents a response from an API method that returns a collection of Tld struct.
+type tldsResponse struct {
+	Response
+	Data []Tld `json:"data"`
+}
+
+// tldExtendedAttributesResponse represents a response from an API method that returns
+// a collection of Tld extended attributes.
+type tldExtendedAttributesResponse struct {
+	Response
+	Data []TldExtendedAttribute `json:"data"`
+}
+
+// ListTlds lists the supported TLDs.
+//
+// See https://developer.dnsimple.com/v2/tlds/#list
+func (s *TldsService) ListTlds(options *ListOptions) (*tldsResponse, error) {
+	path := versioned("/tlds")
+	tldsResponse := &tldsResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, tldsResponse)
+	if err != nil {
+		return tldsResponse, err
+	}
+
+	tldsResponse.HttpResponse = resp
+	return tldsResponse, nil
+}
+
+// GetTld fetches a TLD.
+//
+// See https://developer.dnsimple.com/v2/tlds/#get
+func (s *TldsService) GetTld(tld string) (*tldResponse, error) {
+	path := versioned(fmt.Sprintf("/tlds/%s", tld))
+	tldResponse := &tldResponse{}
+
+	resp, err := s.client.get(path, tldResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	tldResponse.HttpResponse = resp
+	return tldResponse, nil
+}
+
+// GetTld fetches the extended attributes of a TLD.
+//
+// See https://developer.dnsimple.com/v2/tlds/#get
+func (s *TldsService) GetTldExtendedAttributes(tld string) (*tldExtendedAttributesResponse, error) {
+	path := versioned(fmt.Sprintf("/tlds/%s/extended_attributes", tld))
+	tldResponse := &tldExtendedAttributesResponse{}
+
+	resp, err := s.client.get(path, tldResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	tldResponse.HttpResponse = resp
+	return tldResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/users.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/users.go
@@ -1,0 +1,7 @@
+package dnsimple
+
+// User represents a DNSimple user.
+type User struct {
+	ID    int    `json:"id,omitempty"`
+	Email string `json:"email,omitempty"`
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/vanity_name_server.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/vanity_name_server.go
@@ -1,0 +1,65 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// VanityNameServersService handles communication with Vanity Name Servers
+// methods of the DNSimple API.
+//
+// See https://developer.dnsimple.com/v2/vanity/
+type VanityNameServersService struct {
+	client *Client
+}
+
+// VanityNameServer represents data for a single vanity name server
+type VanityNameServer struct {
+	ID        int    `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	IPv4      string `json:"ipv4,omitempty"`
+	IPv6      string `json:"ipv6,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+func vanityNameServerPath(accountID string, domainID string) string {
+	return fmt.Sprintf("/%v/vanity/%v", accountID, domainID)
+}
+
+// vanityNameServerResponse represents a response for vanity name server enable and disable operations.
+type vanityNameServerResponse struct {
+	Response
+	Data []VanityNameServer `json:"data"`
+}
+
+// EnableVanityNameServers Vanity Name Servers for the given domain
+//
+// See https://developer.dnsimple.com/v2/vanity/#enable
+func (s *VanityNameServersService) EnableVanityNameServers(accountID string, domainID string) (*vanityNameServerResponse, error) {
+	path := versioned(vanityNameServerPath(accountID, domainID))
+	vanityNameServerResponse := &vanityNameServerResponse{}
+
+	resp, err := s.client.put(path, nil, vanityNameServerResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	vanityNameServerResponse.HttpResponse = resp
+	return vanityNameServerResponse, nil
+}
+
+// DisableVanityNameServers Vanity Name Servers for the given domain
+//
+// See https://developer.dnsimple.com/v2/vanity/#disable
+func (s *VanityNameServersService) DisableVanityNameServers(accountID string, domainID string) (*vanityNameServerResponse, error) {
+	path := versioned(vanityNameServerPath(accountID, domainID))
+	vanityNameServerResponse := &vanityNameServerResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	vanityNameServerResponse.HttpResponse = resp
+	return vanityNameServerResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/webhooks.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/webhooks.go
@@ -1,0 +1,103 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// WebhooksService handles communication with the webhook related
+// methods of the DNSimple API.
+//
+// See https://developer.dnsimple.com/v2/webhooks
+type WebhooksService struct {
+	client *Client
+}
+
+// Webhook represents a DNSimple webhook.
+type Webhook struct {
+	ID  int    `json:"id,omitempty"`
+	URL string `json:"url,omitempty"`
+}
+
+func webhookPath(accountID string, webhookID int) (path string) {
+	path = fmt.Sprintf("/%v/webhooks", accountID)
+	if webhookID != 0 {
+		path = fmt.Sprintf("%v/%v", path, webhookID)
+	}
+	return
+}
+
+// webhookResponse represents a response from an API method that returns a Webhook struct.
+type webhookResponse struct {
+	Response
+	Data *Webhook `json:"data"`
+}
+
+// webhookResponse represents a response from an API method that returns a collection of Webhook struct.
+type webhooksResponse struct {
+	Response
+	Data []Webhook `json:"data"`
+}
+
+// ListWebhooks lists the webhooks for an account.
+//
+// See https://developer.dnsimple.com/v2/webhooks#list
+func (s *WebhooksService) ListWebhooks(accountID string, _ *ListOptions) (*webhooksResponse, error) {
+	path := versioned(webhookPath(accountID, 0))
+	webhooksResponse := &webhooksResponse{}
+
+	resp, err := s.client.get(path, webhooksResponse)
+	if err != nil {
+		return webhooksResponse, err
+	}
+
+	webhooksResponse.HttpResponse = resp
+	return webhooksResponse, nil
+}
+
+// CreateWebhook creates a new webhook.
+//
+// See https://developer.dnsimple.com/v2/webhooks#create
+func (s *WebhooksService) CreateWebhook(accountID string, webhookAttributes Webhook) (*webhookResponse, error) {
+	path := versioned(webhookPath(accountID, 0))
+	webhookResponse := &webhookResponse{}
+
+	resp, err := s.client.post(path, webhookAttributes, webhookResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	webhookResponse.HttpResponse = resp
+	return webhookResponse, nil
+}
+
+// GetWebhook fetches a webhook.
+//
+// See https://developer.dnsimple.com/v2/webhooks#get
+func (s *WebhooksService) GetWebhook(accountID string, webhookID int) (*webhookResponse, error) {
+	path := versioned(webhookPath(accountID, webhookID))
+	webhookResponse := &webhookResponse{}
+
+	resp, err := s.client.get(path, webhookResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	webhookResponse.HttpResponse = resp
+	return webhookResponse, nil
+}
+
+// DeleteWebhook PERMANENTLY deletes a webhook from the account.
+//
+// See https://developer.dnsimple.com/v2/webhooks#delete
+func (s *WebhooksService) DeleteWebhook(accountID string, webhookID int) (*webhookResponse, error) {
+	path := versioned(webhookPath(accountID, webhookID))
+	webhookResponse := &webhookResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	webhookResponse.HttpResponse = resp
+	return webhookResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/zones.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/zones.go
@@ -1,0 +1,108 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// ZonesService handles communication with the zone related
+// methods of the DNSimple API.
+//
+// See https://developer.dnsimple.com/v2/zones/
+type ZonesService struct {
+	client *Client
+}
+
+// Zone represents a Zone in DNSimple.
+type Zone struct {
+	ID        int    `json:"id,omitempty"`
+	AccountID int    `json:"account_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Reverse   bool   `json:"reverse,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// ZoneFile represents a Zone File in DNSimple.
+type ZoneFile struct {
+	Zone string `json:"zone,omitempty"`
+}
+
+// zoneResponse represents a response from an API method that returns a Zone struct.
+type zoneResponse struct {
+	Response
+	Data *Zone `json:"data"`
+}
+
+// zonesResponse represents a response from an API method that returns a collection of Zone struct.
+type zonesResponse struct {
+	Response
+	Data []Zone `json:"data"`
+}
+
+// zoneFileResponse represents a response from an API method that returns a ZoneFile struct.
+type zoneFileResponse struct {
+	Response
+	Data *ZoneFile `json:"data"`
+}
+
+// ZoneListOptions specifies the optional parameters you can provide
+// to customize the ZonesService.ListZones method.
+type ZoneListOptions struct {
+	// Select domains where the name contains given string.
+	NameLike string `url:"name_like,omitempty"`
+
+	ListOptions
+}
+
+// ListZones the zones for an account.
+//
+// See https://developer.dnsimple.com/v2/zones/#list
+func (s *ZonesService) ListZones(accountID string, options *ZoneListOptions) (*zonesResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/zones", accountID))
+	zonesResponse := &zonesResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, zonesResponse)
+	if err != nil {
+		return zonesResponse, err
+	}
+
+	zonesResponse.HttpResponse = resp
+	return zonesResponse, nil
+}
+
+// GetZone fetches a zone.
+//
+// See https://developer.dnsimple.com/v2/zones/#get
+func (s *ZonesService) GetZone(accountID string, zoneName string) (*zoneResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/zones/%v", accountID, zoneName))
+	zoneResponse := &zoneResponse{}
+
+	resp, err := s.client.get(path, zoneResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	zoneResponse.HttpResponse = resp
+	return zoneResponse, nil
+}
+
+// GetZoneFile fetches a zone file.
+//
+// See https://developer.dnsimple.com/v2/zones/#get-file
+func (s *ZonesService) GetZoneFile(accountID string, zoneName string) (*zoneFileResponse, error) {
+	path := versioned(fmt.Sprintf("/%v/zones/%v/file", accountID, zoneName))
+	zoneFileResponse := &zoneFileResponse{}
+
+	resp, err := s.client.get(path, zoneFileResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	zoneFileResponse.HttpResponse = resp
+	return zoneFileResponse, nil
+}

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/zones_records.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/zones_records.go
@@ -1,0 +1,142 @@
+package dnsimple
+
+import (
+	"fmt"
+)
+
+// ZoneRecord represents a DNS record in DNSimple.
+type ZoneRecord struct {
+	ID           int      `json:"id,omitempty"`
+	ZoneID       string   `json:"zone_id,omitempty"`
+	ParentID     int      `json:"parent_id,omitempty"`
+	Type         string   `json:"type,omitempty"`
+	Name         string   `json:"name"`
+	Content      string   `json:"content,omitempty"`
+	TTL          int      `json:"ttl,omitempty"`
+	Priority     int      `json:"priority,omitempty"`
+	SystemRecord bool     `json:"system_record,omitempty"`
+	Regions      []string `json:"regions,omitempty"`
+	CreatedAt    string   `json:"created_at,omitempty"`
+	UpdatedAt    string   `json:"updated_at,omitempty"`
+}
+
+func zoneRecordPath(accountID string, zoneID string, recordID int) (path string) {
+	path = fmt.Sprintf("/%v/zones/%v/records", accountID, zoneID)
+	if recordID != 0 {
+		path += fmt.Sprintf("/%d", recordID)
+	}
+	return
+}
+
+// zoneRecordResponse represents a response from an API method that returns a ZoneRecord struct.
+type zoneRecordResponse struct {
+	Response
+	Data *ZoneRecord `json:"data"`
+}
+
+// zoneRecordsResponse represents a response from an API method that returns a collection of ZoneRecord struct.
+type zoneRecordsResponse struct {
+	Response
+	Data []ZoneRecord `json:"data"`
+}
+
+// ZoneRecordListOptions specifies the optional parameters you can provide
+// to customize the ZonesService.ListZoneRecords method.
+type ZoneRecordListOptions struct {
+	// Select records where the name matches given string.
+	Name string `url:"name,omitempty"`
+
+	// Select records where the name contains given string.
+	NameLike string `url:"name_like,omitempty"`
+
+	// Select records of given type.
+	// Eg. TXT, A, NS.
+	Type string `url:"type,omitempty"`
+
+	ListOptions
+}
+
+// ListRecords lists the zone records for a zone.
+//
+// See https://developer.dnsimple.com/v2/zones/#list
+func (s *ZonesService) ListRecords(accountID string, zoneID string, options *ZoneRecordListOptions) (*zoneRecordsResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneID, 0))
+	recordsResponse := &zoneRecordsResponse{}
+
+	path, err := addURLQueryOptions(path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.get(path, recordsResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	recordsResponse.HttpResponse = resp
+	return recordsResponse, nil
+}
+
+// CreateRecord creates a zone record.
+//
+// See https://developer.dnsimple.com/v2/zones/#create
+func (s *ZonesService) CreateRecord(accountID string, zoneID string, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneID, 0))
+	recordResponse := &zoneRecordResponse{}
+
+	resp, err := s.client.post(path, recordAttributes, recordResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	recordResponse.HttpResponse = resp
+	return recordResponse, nil
+}
+
+// GetRecord fetches a zone record.
+//
+// See https://developer.dnsimple.com/v2/zones/#get
+func (s *ZonesService) GetRecord(accountID string, zoneID string, recordID int) (*zoneRecordResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneID, recordID))
+	recordResponse := &zoneRecordResponse{}
+
+	resp, err := s.client.get(path, recordResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	recordResponse.HttpResponse = resp
+	return recordResponse, nil
+}
+
+// UpdateRecord updates a zone record.
+//
+// See https://developer.dnsimple.com/v2/zones/#update
+func (s *ZonesService) UpdateRecord(accountID string, zoneID string, recordID int, recordAttributes ZoneRecord) (*zoneRecordResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneID, recordID))
+	recordResponse := &zoneRecordResponse{}
+	resp, err := s.client.patch(path, recordAttributes, recordResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	recordResponse.HttpResponse = resp
+	return recordResponse, nil
+}
+
+// DeleteRecord PERMANENTLY deletes a zone record from the zone.
+//
+// See https://developer.dnsimple.com/v2/zones/#delete
+func (s *ZonesService) DeleteRecord(accountID string, zoneID string, recordID int) (*zoneRecordResponse, error) {
+	path := versioned(zoneRecordPath(accountID, zoneID, recordID))
+	recordResponse := &zoneRecordResponse{}
+
+	resp, err := s.client.delete(path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	recordResponse.HttpResponse = resp
+	return recordResponse, nil
+}

--- a/vendor/github.com/google/go-querystring/LICENSE
+++ b/vendor/github.com/google/go-querystring/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013 Google. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/google/go-querystring/query/encode.go
+++ b/vendor/github.com/google/go-querystring/query/encode.go
@@ -1,0 +1,320 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package query implements encoding of structs into URL query parameters.
+//
+// As a simple example:
+//
+// 	type Options struct {
+// 		Query   string `url:"q"`
+// 		ShowAll bool   `url:"all"`
+// 		Page    int    `url:"page"`
+// 	}
+//
+// 	opt := Options{ "foo", true, 2 }
+// 	v, _ := query.Values(opt)
+// 	fmt.Print(v.Encode()) // will output: "q=foo&all=true&page=2"
+//
+// The exact mapping between Go values and url.Values is described in the
+// documentation for the Values() function.
+package query
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var timeType = reflect.TypeOf(time.Time{})
+
+var encoderType = reflect.TypeOf(new(Encoder)).Elem()
+
+// Encoder is an interface implemented by any type that wishes to encode
+// itself into URL values in a non-standard way.
+type Encoder interface {
+	EncodeValues(key string, v *url.Values) error
+}
+
+// Values returns the url.Values encoding of v.
+//
+// Values expects to be passed a struct, and traverses it recursively using the
+// following encoding rules.
+//
+// Each exported struct field is encoded as a URL parameter unless
+//
+//	- the field's tag is "-", or
+//	- the field is empty and its tag specifies the "omitempty" option
+//
+// The empty values are false, 0, any nil pointer or interface value, any array
+// slice, map, or string of length zero, and any time.Time that returns true
+// for IsZero().
+//
+// The URL parameter name defaults to the struct field name but can be
+// specified in the struct field's tag value.  The "url" key in the struct
+// field's tag value is the key name, followed by an optional comma and
+// options.  For example:
+//
+// 	// Field is ignored by this package.
+// 	Field int `url:"-"`
+//
+// 	// Field appears as URL parameter "myName".
+// 	Field int `url:"myName"`
+//
+// 	// Field appears as URL parameter "myName" and the field is omitted if
+// 	// its value is empty
+// 	Field int `url:"myName,omitempty"`
+//
+// 	// Field appears as URL parameter "Field" (the default), but the field
+// 	// is skipped if empty.  Note the leading comma.
+// 	Field int `url:",omitempty"`
+//
+// For encoding individual field values, the following type-dependent rules
+// apply:
+//
+// Boolean values default to encoding as the strings "true" or "false".
+// Including the "int" option signals that the field should be encoded as the
+// strings "1" or "0".
+//
+// time.Time values default to encoding as RFC3339 timestamps.  Including the
+// "unix" option signals that the field should be encoded as a Unix time (see
+// time.Unix())
+//
+// Slice and Array values default to encoding as multiple URL values of the
+// same name.  Including the "comma" option signals that the field should be
+// encoded as a single comma-delimited value.  Including the "space" option
+// similarly encodes the value as a single space-delimited string. Including
+// the "semicolon" option will encode the value as a semicolon-delimited string.
+// Including the "brackets" option signals that the multiple URL values should
+// have "[]" appended to the value name. "numbered" will append a number to
+// the end of each incidence of the value name, example:
+// name0=value0&name1=value1, etc.
+//
+// Anonymous struct fields are usually encoded as if their inner exported
+// fields were fields in the outer struct, subject to the standard Go
+// visibility rules.  An anonymous struct field with a name given in its URL
+// tag is treated as having that name, rather than being anonymous.
+//
+// Non-nil pointer values are encoded as the value pointed to.
+//
+// Nested structs are encoded including parent fields in value names for
+// scoping. e.g:
+//
+// 	"user[name]=acme&user[addr][postcode]=1234&user[addr][city]=SFO"
+//
+// All other values are encoded using their default string representation.
+//
+// Multiple fields that encode to the same URL parameter name will be included
+// as multiple URL values of the same name.
+func Values(v interface{}) (url.Values, error) {
+	values := make(url.Values)
+	val := reflect.ValueOf(v)
+	for val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return values, nil
+		}
+		val = val.Elem()
+	}
+
+	if v == nil {
+		return values, nil
+	}
+
+	if val.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("query: Values() expects struct input. Got %v", val.Kind())
+	}
+
+	err := reflectValue(values, val, "")
+	return values, err
+}
+
+// reflectValue populates the values parameter from the struct fields in val.
+// Embedded structs are followed recursively (using the rules defined in the
+// Values function documentation) breadth-first.
+func reflectValue(values url.Values, val reflect.Value, scope string) error {
+	var embedded []reflect.Value
+
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		sf := typ.Field(i)
+		if sf.PkgPath != "" && !sf.Anonymous { // unexported
+			continue
+		}
+
+		sv := val.Field(i)
+		tag := sf.Tag.Get("url")
+		if tag == "-" {
+			continue
+		}
+		name, opts := parseTag(tag)
+		if name == "" {
+			if sf.Anonymous && sv.Kind() == reflect.Struct {
+				// save embedded struct for later processing
+				embedded = append(embedded, sv)
+				continue
+			}
+
+			name = sf.Name
+		}
+
+		if scope != "" {
+			name = scope + "[" + name + "]"
+		}
+
+		if opts.Contains("omitempty") && isEmptyValue(sv) {
+			continue
+		}
+
+		if sv.Type().Implements(encoderType) {
+			if !reflect.Indirect(sv).IsValid() {
+				sv = reflect.New(sv.Type().Elem())
+			}
+
+			m := sv.Interface().(Encoder)
+			if err := m.EncodeValues(name, &values); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if sv.Kind() == reflect.Slice || sv.Kind() == reflect.Array {
+			var del byte
+			if opts.Contains("comma") {
+				del = ','
+			} else if opts.Contains("space") {
+				del = ' '
+			} else if opts.Contains("semicolon") {
+				del = ';'
+			} else if opts.Contains("brackets") {
+				name = name + "[]"
+			}
+
+			if del != 0 {
+				s := new(bytes.Buffer)
+				first := true
+				for i := 0; i < sv.Len(); i++ {
+					if first {
+						first = false
+					} else {
+						s.WriteByte(del)
+					}
+					s.WriteString(valueString(sv.Index(i), opts))
+				}
+				values.Add(name, s.String())
+			} else {
+				for i := 0; i < sv.Len(); i++ {
+					k := name
+					if opts.Contains("numbered") {
+						k = fmt.Sprintf("%s%d", name, i)
+					}
+					values.Add(k, valueString(sv.Index(i), opts))
+				}
+			}
+			continue
+		}
+
+		for sv.Kind() == reflect.Ptr {
+			if sv.IsNil() {
+				break
+			}
+			sv = sv.Elem()
+		}
+
+		if sv.Type() == timeType {
+			values.Add(name, valueString(sv, opts))
+			continue
+		}
+
+		if sv.Kind() == reflect.Struct {
+			reflectValue(values, sv, name)
+			continue
+		}
+
+		values.Add(name, valueString(sv, opts))
+	}
+
+	for _, f := range embedded {
+		if err := reflectValue(values, f, scope); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// valueString returns the string representation of a value.
+func valueString(v reflect.Value, opts tagOptions) string {
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() == reflect.Bool && opts.Contains("int") {
+		if v.Bool() {
+			return "1"
+		}
+		return "0"
+	}
+
+	if v.Type() == timeType {
+		t := v.Interface().(time.Time)
+		if opts.Contains("unix") {
+			return strconv.FormatInt(t.Unix(), 10)
+		}
+		return t.Format(time.RFC3339)
+	}
+
+	return fmt.Sprint(v.Interface())
+}
+
+// isEmptyValue checks if a value should be considered empty for the purposes
+// of omitting fields with the "omitempty" option.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+
+	if v.Type() == timeType {
+		return v.Interface().(time.Time).IsZero()
+	}
+
+	return false
+}
+
+// tagOptions is the string following a comma in a struct field's "url" tag, or
+// the empty string. It does not include the leading comma.
+type tagOptions []string
+
+// parseTag splits a struct field's url tag into its name and comma-separated
+// options.
+func parseTag(tag string) (string, tagOptions) {
+	s := strings.Split(tag, ",")
+	return s[0], s[1:]
+}
+
+// Contains checks whether the tagOptions contains the specified option.
+func (o tagOptions) Contains(option string) bool {
+	for _, s := range o {
+		if s == option {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -688,6 +688,12 @@
 			"revisionTime": "2017-06-08T00:51:49Z"
 		},
 		{
+			"checksumSHA1": "7cHRrdndBsM+z1FRsp5IhfDgU9E=",
+			"path": "github.com/dnsimple/dnsimple-go/dnsimple",
+			"revision": "9641549ef4d560b09b6f44d9f394af0efcb438ee",
+			"revisionTime": "2017-12-11T13:40:23Z"
+		},
+		{
 			"path": "github.com/docker/docker/api/types/swarm",
 			"revision": ""
 		},
@@ -825,6 +831,12 @@
 			"path": "github.com/golang/protobuf/proto",
 			"revision": "69b215d01a5606c843240eab4937eab3acee6530",
 			"revisionTime": "2017-02-17T23:44:32Z"
+		},
+		{
+			"checksumSHA1": "p3IB18uJRs4dL2K5yx24MrLYE9A=",
+			"path": "github.com/google/go-querystring/query",
+			"revision": "53e6ce116135b80d037921a7fdd5138cf32d7a8a",
+			"revisionTime": "2017-01-11T10:11:55Z"
 		},
 		{
 			"checksumSHA1": "V/53BpqgOkSDZCX6snQCAkdO2fM=",
@@ -1897,10 +1909,10 @@
 			"revisionTime": "2017-02-19T04:51:39Z"
 		},
 		{
-			"checksumSHA1": "JsIMAs8XEDRm7+PSQ5yTkeNmNQE=",
+			"checksumSHA1": "5ttnmqA3Mi5YFdy0+6Qq9wP9qTY=",
 			"path": "github.com/xenolf/lego/providers/dns/dnsimple",
-			"revision": "6cac0ea7d8b28c889f709ec7fa92e92b82f490dd",
-			"revisionTime": "2017-02-19T04:51:39Z"
+			"revision": "b929aa5aab5ad2e197bb3d74ef99fac61bfa47bc",
+			"revisionTime": "2017-11-15T10:03:00Z"
 		},
 		{
 			"checksumSHA1": "MiF+MC9IOe/4eNeI5x4wJSq/wkc=",


### PR DESCRIPTION
This will allow the usage of API v2 with dnsimple lego provider which aligns with the current dnsimple terraform provider.